### PR TITLE
fix: replace link to archived feedback repo with main repo

### DIFF
--- a/docs/contact.md
+++ b/docs/contact.md
@@ -4,11 +4,10 @@ Please do not hesitate to contact us about any occasion.
 We provide multiple channels to get in contact for different topics:
 
 - [💡 I have an idea (aka feature request or requirement)](https://github.com/orgs/openqda/discussions/categories/ideas)
-
 - [🤝 I have a question or need help and there is no answer in the docs](https://github.com/orgs/openqda/discussions/categories/q-a)
 - 🔨 I have a technical issue
-    - [🐞 I'm sure it's a bug, and it's reproducible](https://github.com/openqda/feedback/issues)
+    - [🐞 I'm sure it's a bug, and it's reproducible](https://github.com/openqda/openqda/issues)
     - [❓ I'm not sure](https://github.com/orgs/openqda/discussions/categories/general)
-- [🛡️ I have a security issue to report](https://github.com/openqda/feedback/security/policy)
+- [🛡️ I have a security issue to report](https://github.com/openqda/openqda/security/policy)
 - [🧙‍♂️ I want to improve the documentation](https://github.com/openqda/user-docs)
 - [📧 I have something else or I have no GitHub account](mailto:openqda@uni-bremen.de)

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ features:
   - title: Your feedback matters!
     details: OpenQDA thrives by incorporating what the QDA community needs. For that we need your feedback to
     icon: 📢
-    link: https://github.com/openqda/feedback/
+    link: https://github.com/orgs/openqda/discussions
     linkText: Give feedback and join the discussion
   - title: Join the development!
     details: OpenQDA is publicly developed on GitHub, contributions are welcomed!


### PR DESCRIPTION
Fixes links to our archived feedback repository with our main repo to consolidate feedback in a single place